### PR TITLE
Update assemble-routed-files.sh

### DIFF
--- a/scripts/assemble-routed-files.sh
+++ b/scripts/assemble-routed-files.sh
@@ -3,7 +3,7 @@ set -e
 
 if [ -z $4 ]
 then
-	echo "usage:$0 <file w/ list of routed files> <hydra config file> <number of processes> <punt parameter>"
+	echo "usage:$0 <hydra config file> <file w/ list of routed files> <number of processes> <punt parameter>"
 	exit
 fi
 


### PR DESCRIPTION
Documentation (readme & "usage") of the script does not allow to feed the CONFIG & ROUTED_FILES variables properly.
Permuted the label of $1 and $2 in "usage" to make them consistent with the rest of the script. 
It would be great to update the Readme accordingly (same typo).